### PR TITLE
2022-01-28_0332 - JeffreyBodin - WaldyBotTwitch - JeffreyBodin - added   + commit log   + versioned history of forks to date 2022-01-28 - LICENSE      ```js   MIT License     Copyright (c) 2022 Jeffrey Bodin   ```  - is ^ branch    > [ 2022-01-28_0236--branch-to-fix-this-err ]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,9 +136,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -284,9 +284,9 @@
       }
     },
     "ws": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.0.tgz",
-      "integrity": "sha512-H3dGVdGvW2H8bnYpIDc3u3LH8Wue3Qh+Zto6aXXFzvESkTVT6rAfKR6tR/+coaUvxs8yHtmNV0uioBF62ZGSTg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
+      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,9 +172,12 @@
       "integrity": "sha1-n7CwmbzSoCGUDmA8ZCVNwAPZp6g="
     },
     "node-fetch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
     },
     "qs": {
       "version": "6.5.2",
@@ -223,6 +226,11 @@
         }
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "twitch-js": {
       "version": "2.0.0-beta.21",
       "resolved": "https://registry.npmjs.org/twitch-js/-/twitch-js-2.0.0-beta.21.tgz",
@@ -256,10 +264,24 @@
       "integrity": "sha1-8BZSoLS7lByxi7emJI14D9AVAkU=",
       "optional": true
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
       "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "ws": {
       "version": "6.1.0",


### PR DESCRIPTION
2022-01-28_0332
- JeffreyBodin
- WaldyBotTwitch
- JeffreyBodin
- added
  + commit log
  + versioned history of forks to date 2022-01-28
- LICENSE
  
  ```js
  MIT License 

  Copyright (c) 2022 Jeffrey Bodin
  ```

- is ^ branch 
  > [ 2022-01-28_0236--branch-to-fix-this-err ]

-----



```md
2022-01-28_0258
- JeffreyBodin
- WaldyBotTwitch
- JeffreyBodin
- added
  - all of these commits
  - as most are in ordered and cannot seem to be added correctly to the master
  - of which all must be added correctly
- changes 'this'
  - the commit log itself
  - squash and merge?
    ||
    rebase and merge?
- note on ^ "changes 'this'"

  ->  Would appreciate a "dummy" log to populate.
  - Commit to master fr temp

  - Encompassing all of log commits

  - As the final commit
  
    Unlikely 🤷‍♀️
  



2022-01-28_0229
- JeffreyBodin
- WaldyBotTwitch
- JeffreyBodin
- changes
-> 'Rebase and merge'

> #Rebase Commit [#12]
> 
> 2022-01-28_0203
> 
> * JeffreyBodin
> * WaldyBotTwitch
> * JeffreyBodin
> * changes
>   -- adding this commit
>   -- which is a copy of previous commit
>   -- within this forked pull to the OG rebase that I just completed
>   -- to ensure continuity
>   -- within the body of work
>   -- as is important and appears I overlooked necessity of opening ANOTHER pull request
> * see
>   2022-01-28_0014
>   
>   * JeffreyBodin
>   * WaldyBotTwitch
>   * JeffreyBodin
>   * note
>     -> 'this' is 'github.com/[Bump node-fetch from 2.2.0 to 2.6.7 #12](https://github.com/JeffreyBodin/WaldyBotTwitch/pull/12)'
>   * an
>     -> 'Rebase' to Merge to Master (Origin)
>   * is
>     > ##### MAJOR RELEASE
>   * is follow-up
>     -> for prev security flags presented
>     in
>     -> code
>     -> twitter api integrous architecture
>     within
>     -> "architecture"
>     -> 'WaldyBotTwitch'
>   * 'this' commit denotes a 'Release'++
>     -> 'WaldyBotTwitch'
>   * ie
>     -> increments the versioning of WaldyBotTwitch
>   * was
>     -> 'WaldyBotTwitch v0.0.1-pre_alpha.2.0.0' or 'WaldyBotTwitch v0-0-1-pre_alpha-2-0-0'
>   * now
>     -> 'WaldyBotTwitch v1.0.1-pre_alpha.2.0.0' or 'WaldyBotTwitch v1.0.1-pre_alpha.2-0-0'
>   * denote
>     -> in or with
>     -> documentation && commits
>   * for
>     -> 'WaldyBotTwitch/Releases'
>   * "styling" transition
>     fr -> SemVar (style-Dot Notation)
>     ```
>     Releases as -> 'SemVar (style-Dot Notation)'
>     [
>       Oct 13, 2018
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/v0.0.1-pre_alpha.0.1.0'
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/4e8d582dda72f9dc3e8498127f1ee8d010138c02
>     ],
>     [
>       Oct 14, 2018
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/v0.0.1-pre_alpha.2.0.0 
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/753474e005dbb1f323d244f951155c57275dbee3
>     ]
>     ```
>     
>     
>         
>           
>         
>     
>           
>         
>     
>         
>       
>     to -> SemVar (style-Dash Notation)
>     ```
>     Releases as -> 'SemVar (style-Dot Notation)'
>     [
>       Jan 28, 2022
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/...futureThis'
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/...this
>     ],
>     [
>       Jan 28++, 2022
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/...anyFutureThis
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/...these
>     ]
>     ```
>   
>   # LICENSE
>   Here
>   
>   * for 'this' commit
>     ```js
>     MIT License
>     
>     Copyright (c) 2022 Jeffrey Bodin
>     ```
>   * ie
>     > [WaldyBotTwitch](https://github.com/JeffreyBodin/WaldyBotTwitch/pull/12)
>     
>     
>     
>     * today
>     * ^ 'this' commit "itself" is 2022
>   
>   See
>   
>   * for all (commits, additions, deletions, contribution, fork, pull, push, rebase)
>     > LICENSE (2018)(MIT)
>     > [6c3777a](https://github.com/JeffreyBodin/WaldyBotTwitch/commit/6c3777a8aaa52e2909224f0eaa30694f2865bb7f)
>     
>     
>     
>     * ^ init commit for 'WaldyBotTwitch'
>   * ie
>     -> MY declaration of typeset boolean completion
>     &&
>     THE license for 'WaldyBotTwitch'
>   
>   LICENSE .RAW
>   ```js
>   MIT License
>   
>   Copyright (c) 2018 Jeffrey Bodin
>   
>   Permission is hereby granted, free of charge, to any person obtaining a copy
>   of this software and associated documentation files (the "Software"), to deal
>   in the Software without restriction, including without limitation the rights
>   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
>   copies of the Software, and to permit persons to whom the Software is
>   furnished to do so, subject to the following conditions:
>   
>   The above copyright notice and this permission notice shall be included in all
>   copies or substantial portions of the Software.
>   
>   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
>   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
>   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
>   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
>   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
>   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
>   SOFTWARE.
>   ```
>   
>   
>       
>         
>       
>   
>         
>       
>   
>       
>     
>   
>   * ^ For
>     > LICENSE
>     > OWNERSHIP
>     > PATENTABILITY
>     > ASSOCIATION ('the UNITED STATES OF AMERICA')
>   * By
>     > Jeffrey Thomas Bodin
>     > JeffreyBodin
>     > **insert any recognized alias here**
> 
> #12 #Is
> 
> * Dependabot's Commit
> 
> ```lisp
>     Bumps [node-fetch](https://github.com/node-fetch/node-fetch) from 2.2.0 to 2.6.7.
>     - [Release notes](https://github.com/node-fetch/node-fetch/releases)
>     - [Changelog](https://github.com/node-fetch/node-fetch/blob/main/docs/CHANGELOG.md)
>     - [Commits](https://github.com/node-fetch/node-fetch/compare/v2.2.0...v2.6.7)
>     
>     ---
>     updated-dependencies:
>     - dependency-name: node-fetch
>       dependency-type: indirect
>     ...
>     
>     Signed-off-by: dependabot[bot] <support@github.com>
> ```

_Originally posted by @JeffreyBodin in https://github.com/JeffreyBodin/WaldyBotTwitch/issues/13#issuecomment-1023995059_




2022-01-28_0217
- JeffreyBodin
- WaldyBotTwitch
- JeffreyBodin
- done
-> reopened the pull req
- is
-> 'Rebase and merge'

> #Rebase Commit [#12]
> 
> 2022-01-28_0203
> 
> * JeffreyBodin
> * WaldyBotTwitch
> * JeffreyBodin
> * changes
>   -- adding this commit
>   -- which is a copy of previous commit
>   -- within this forked pull to the OG rebase that I just completed
>   -- to ensure continuity
>   -- within the body of work
>   -- as is important and appears I overlooked necessity of opening ANOTHER pull request
> * see
>   2022-01-28_0014
>   
>   * JeffreyBodin
>   * WaldyBotTwitch
>   * JeffreyBodin
>   * note
>     -> 'this' is 'github.com/[Bump node-fetch from 2.2.0 to 2.6.7 #12](https://github.com/JeffreyBodin/WaldyBotTwitch/pull/12)'
>   * an
>     -> 'Rebase' to Merge to Master (Origin)
>   * is
>     > ##### MAJOR RELEASE
>   * is follow-up
>     -> for prev security flags presented
>     in
>     -> code
>     -> twitter api integrous architecture
>     within
>     -> "architecture"
>     -> 'WaldyBotTwitch'
>   * 'this' commit denotes a 'Release'++
>     -> 'WaldyBotTwitch'
>   * ie
>     -> increments the versioning of WaldyBotTwitch
>   * was
>     -> 'WaldyBotTwitch v0.0.1-pre_alpha.2.0.0' or 'WaldyBotTwitch v0-0-1-pre_alpha-2-0-0'
>   * now
>     -> 'WaldyBotTwitch v1.0.1-pre_alpha.2.0.0' or 'WaldyBotTwitch v1.0.1-pre_alpha.2-0-0'
>   * denote
>     -> in or with
>     -> documentation && commits
>   * for
>     -> 'WaldyBotTwitch/Releases'
>   * "styling" transition
>     fr -> SemVar (style-Dot Notation)
>     ```
>     Releases as -> 'SemVar (style-Dot Notation)'
>     [
>       Oct 13, 2018
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/v0.0.1-pre_alpha.0.1.0'
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/4e8d582dda72f9dc3e8498127f1ee8d010138c02
>     ],
>     [
>       Oct 14, 2018
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/v0.0.1-pre_alpha.2.0.0 
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/753474e005dbb1f323d244f951155c57275dbee3
>     ]
>     ```
>     
>     
>         
>           
>         
>     
>           
>         
>     
>         
>       
>     to -> SemVar (style-Dash Notation)
>     ```
>     Releases as -> 'SemVar (style-Dot Notation)'
>     [
>       Jan 28, 2022
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/...futureThis'
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/...this
>     ],
>     [
>       Jan 28++, 2022
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/...anyFutureThis
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/...these
>     ]
>     ```
>   
>   # LICENSE
>   Here
>   
>   * for 'this' commit
>     ```js
>     MIT License
>     
>     Copyright (c) 2022 Jeffrey Bodin
>     ```
>   * ie
>     > [WaldyBotTwitch](https://github.com/JeffreyBodin/WaldyBotTwitch/pull/12)
>     
>     
>     
>     * today
>     * ^ 'this' commit "itself" is 2022
>   
>   See
>   
>   * for all (commits, additions, deletions, contribution, fork, pull, push, rebase)
>     > LICENSE (2018)(MIT)
>     > [6c3777a](https://github.com/JeffreyBodin/WaldyBotTwitch/commit/6c3777a8aaa52e2909224f0eaa30694f2865bb7f)
>     
>     
>     
>     * ^ init commit for 'WaldyBotTwitch'
>   * ie
>     -> MY declaration of typeset boolean completion
>     &&
>     THE license for 'WaldyBotTwitch'
>   
>   LICENSE .RAW
>   ```js
>   MIT License
>   
>   Copyright (c) 2018 Jeffrey Bodin
>   
>   Permission is hereby granted, free of charge, to any person obtaining a copy
>   of this software and associated documentation files (the "Software"), to deal
>   in the Software without restriction, including without limitation the rights
>   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
>   copies of the Software, and to permit persons to whom the Software is
>   furnished to do so, subject to the following conditions:
>   
>   The above copyright notice and this permission notice shall be included in all
>   copies or substantial portions of the Software.
>   
>   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
>   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
>   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
>   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
>   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
>   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
>   SOFTWARE.
>   ```
>   
>   
>       
>         
>       
>   
>         
>       
>   
>       
>     
>   
>   * ^ For
>     > LICENSE
>     > OWNERSHIP
>     > PATENTABILITY
>     > ASSOCIATION ('the UNITED STATES OF AMERICA')
>   * By
>     > Jeffrey Thomas Bodin
>     > JeffreyBodin
>     > **insert any recognized alias here**
> 
> #12 #Is
> 
> * Dependabot's Commit
> 
> ```lisp
>     Bumps [node-fetch](https://github.com/node-fetch/node-fetch) from 2.2.0 to 2.6.7.
>     - [Release notes](https://github.com/node-fetch/node-fetch/releases)
>     - [Changelog](https://github.com/node-fetch/node-fetch/blob/main/docs/CHANGELOG.md)
>     - [Commits](https://github.com/node-fetch/node-fetch/compare/v2.2.0...v2.6.7)
>     
>     ---
>     updated-dependencies:
>     - dependency-name: node-fetch
>       dependency-type: indirect
>     ...
>     
>     Signed-off-by: dependabot[bot] <support@github.com>
> ```

_Originally posted by @JeffreyBodin in https://github.com/JeffreyBodin/WaldyBotTwitch/issues/13#issuecomment-1023984005_




2022-01-28_0216
- JeffreyBodin
- WaldyBotTwitch
- JeffreyBodin
- is
-> 'Rebase and merge'

> #Rebase Commit [#12]
> 
> 2022-01-28_0203
> 
> * JeffreyBodin
> * WaldyBotTwitch
> * JeffreyBodin
> * changes
>   -- adding this commit
>   -- which is a copy of previous commit
>   -- within this forked pull to the OG rebase that I just completed
>   -- to ensure continuity
>   -- within the body of work
>   -- as is important and appears I overlooked necessity of opening ANOTHER pull request
> * see
>   2022-01-28_0014
>   
>   * JeffreyBodin
>   * WaldyBotTwitch
>   * JeffreyBodin
>   * note
>     -> 'this' is 'github.com/[Bump node-fetch from 2.2.0 to 2.6.7 #12](https://github.com/JeffreyBodin/WaldyBotTwitch/pull/12)'
>   * an
>     -> 'Rebase' to Merge to Master (Origin)
>   * is
>     > ##### MAJOR RELEASE
>   * is follow-up
>     -> for prev security flags presented
>     in
>     -> code
>     -> twitter api integrous architecture
>     within
>     -> "architecture"
>     -> 'WaldyBotTwitch'
>   * 'this' commit denotes a 'Release'++
>     -> 'WaldyBotTwitch'
>   * ie
>     -> increments the versioning of WaldyBotTwitch
>   * was
>     -> 'WaldyBotTwitch v0.0.1-pre_alpha.2.0.0' or 'WaldyBotTwitch v0-0-1-pre_alpha-2-0-0'
>   * now
>     -> 'WaldyBotTwitch v1.0.1-pre_alpha.2.0.0' or 'WaldyBotTwitch v1.0.1-pre_alpha.2-0-0'
>   * denote
>     -> in or with
>     -> documentation && commits
>   * for
>     -> 'WaldyBotTwitch/Releases'
>   * "styling" transition
>     fr -> SemVar (style-Dot Notation)
>     ```
>     Releases as -> 'SemVar (style-Dot Notation)'
>     [
>       Oct 13, 2018
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/v0.0.1-pre_alpha.0.1.0'
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/4e8d582dda72f9dc3e8498127f1ee8d010138c02
>     ],
>     [
>       Oct 14, 2018
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/v0.0.1-pre_alpha.2.0.0 
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/753474e005dbb1f323d244f951155c57275dbee3
>     ]
>     ```
>     
>     
>         
>           
>         
>     
>           
>         
>     
>         
>       
>     to -> SemVar (style-Dash Notation)
>     ```
>     Releases as -> 'SemVar (style-Dot Notation)'
>     [
>       Jan 28, 2022
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/...futureThis'
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/...this
>     ],
>     [
>       Jan 28++, 2022
>       github.com/JeffreyBodin/WaldyBotTwitch/tree/...anyFutureThis
>       github.com/JeffreyBodin/WaldyBotTwitch/commit/...these
>     ]
>     ```
>   
>   # LICENSE
>   Here
>   
>   * for 'this' commit
>     ```js
>     MIT License
>     
>     Copyright (c) 2022 Jeffrey Bodin
>     ```
>   * ie
>     > [WaldyBotTwitch](https://github.com/JeffreyBodin/WaldyBotTwitch/pull/12)
>     
>     
>     
>     * today
>     * ^ 'this' commit "itself" is 2022
>   
>   See
>   
>   * for all (commits, additions, deletions, contribution, fork, pull, push, rebase)
>     > LICENSE (2018)(MIT)
>     > [6c3777a](https://github.com/JeffreyBodin/WaldyBotTwitch/commit/6c3777a8aaa52e2909224f0eaa30694f2865bb7f)
>     
>     
>     
>     * ^ init commit for 'WaldyBotTwitch'
>   * ie
>     -> MY declaration of typeset boolean completion
>     &&
>     THE license for 'WaldyBotTwitch'
>   
>   LICENSE .RAW
>   ```js
>   MIT License
>   
>   Copyright (c) 2018 Jeffrey Bodin
>   
>   Permission is hereby granted, free of charge, to any person obtaining a copy
>   of this software and associated documentation files (the "Software"), to deal
>   in the Software without restriction, including without limitation the rights
>   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
>   copies of the Software, and to permit persons to whom the Software is
>   furnished to do so, subject to the following conditions:
>   
>   The above copyright notice and this permission notice shall be included in all
>   copies or substantial portions of the Software.
>   
>   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
>   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
>   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
>   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
>   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
>   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
>   SOFTWARE.
>   ```
>   
>   
>       
>         
>       
>   
>         
>       
>   
>       
>     
>   
>   * ^ For
>     > LICENSE
>     > OWNERSHIP
>     > PATENTABILITY
>     > ASSOCIATION ('the UNITED STATES OF AMERICA')
>   * By
>     > Jeffrey Thomas Bodin
>     > JeffreyBodin
>     > **insert any recognized alias here**
> 
> #12 #Is
> 
> * Dependabot's Commit
> 
> ```lisp
>     Bumps [node-fetch](https://github.com/node-fetch/node-fetch) from 2.2.0 to 2.6.7.
>     - [Release notes](https://github.com/node-fetch/node-fetch/releases)
>     - [Changelog](https://github.com/node-fetch/node-fetch/blob/main/docs/CHANGELOG.md)
>     - [Commits](https://github.com/node-fetch/node-fetch/compare/v2.2.0...v2.6.7)
>     
>     ---
>     updated-dependencies:
>     - dependency-name: node-fetch
>       dependency-type: indirect
>     ...
>     
>     Signed-off-by: dependabot[bot] <support@github.com>
> ```

_Originally posted by @JeffreyBodin in https://github.com/JeffreyBodin/WaldyBotTwitch/issues/13#issuecomment-1023983053_




2022-01-28_0209
- JeffreyBodin
- WaldyBotTwitch
- JeffreyBodin
- changes
-> marking this rdy for review

_Originally posted by @JeffreyBodin in https://github.com/JeffreyBodin/WaldyBotTwitch/issues/13#issuecomment-1023980425_


#Rebase Commit [#12]

2022-01-28_0203
- JeffreyBodin
- WaldyBotTwitch
- JeffreyBodin
- changes
-- adding this commit
-- which is a copy of previous commit
-- within this forked pull to the OG rebase that I just completed
-- to ensure continuity
-- within the body of work
-- as is important and appears I overlooked necessity of opening ANOTHER pull request
- see

    2022-01-28_0014
    - JeffreyBodin
    - WaldyBotTwitch
    - JeffreyBodin
    - note
    -> 'this' is 'github.com/JeffreyBodin/WaldyBotTwitch/pull/12'
    - an 
    -> 'Rebase' to Merge to Master (Origin)
    - is 
      > ##### MAJOR RELEASE #####
    - is follow-up 

      -> for prev security flags presented
      
      in 
      -> code
      -> twitter api integrous architecture
      
      within 
      -> "architecture"
      -> 'WaldyBotTwitch'
    - 'this' commit denotes a 'Release'++
    -> 'WaldyBotTwitch'
    - ie
    -> increments the versioning of WaldyBotTwitch
    - was 
    -> 'WaldyBotTwitch v0.0.1-pre_alpha.2.0.0' or 'WaldyBotTwitch v0-0-1-pre_alpha-2-0-0'
    - now 
    -> 'WaldyBotTwitch v1.0.1-pre_alpha.2.0.0' or 'WaldyBotTwitch v1.0.1-pre_alpha.2-0-0'
    - denote 
    -> in or with
    -> documentation && commits
    - for 
    -> 'WaldyBotTwitch/Releases'

    - "styling" transition

      fr -> SemVar (style-Dot Notation)

          Releases as -> 'SemVar (style-Dot Notation)'
          [
            Oct 13, 2018
            github.com/JeffreyBodin/WaldyBotTwitch/tree/v0.0.1-pre_alpha.0.1.0'
            github.com/JeffreyBodin/WaldyBotTwitch/commit/4e8d582dda72f9dc3e8498127f1ee8d010138c02
          ],
          [
            Oct 14, 2018
            github.com/JeffreyBodin/WaldyBotTwitch/tree/v0.0.1-pre_alpha.2.0.0 
            github.com/JeffreyBodin/WaldyBotTwitch/commit/753474e005dbb1f323d244f951155c57275dbee3
          ]

      to -> SemVar (style-Dash Notation)

          Releases as -> 'SemVar (style-Dot Notation)'
          [
            Jan 28, 2022
            github.com/JeffreyBodin/WaldyBotTwitch/tree/...futureThis'
            github.com/JeffreyBodin/WaldyBotTwitch/commit/...this
          ],
          [
            Jan 28++, 2022
            github.com/JeffreyBodin/WaldyBotTwitch/tree/...anyFutureThis
            github.com/JeffreyBodin/WaldyBotTwitch/commit/...these
          ]

    # LICENSE

    Here
    - for 'this' commit
      ```js
      MIT License
      
      Copyright (c) 2022 Jeffrey Bodin
      ```
    - ie 
      > [WaldyBotTwitch](https://github.com/JeffreyBodin/WaldyBotTwitch/pull/12)
      - today
      - ^ 'this' commit "itself" is 2022

    See 
    - for all (commits, additions, deletions, contribution, fork, pull, push, rebase)
      > LICENSE (2018)(MIT)
      > https://github.com/JeffreyBodin/WaldyBotTwitch/commit/6c3777a8aaa52e2909224f0eaa30694f2865bb7f
      - ^ init commit for 'WaldyBotTwitch'
    - ie 
      -> MY declaration of typeset boolean completion
        && 
        THE license for 'WaldyBotTwitch'

    LICENSE .RAW
    ```js
    MIT License

    Copyright (c) 2018 Jeffrey Bodin

    Permission is hereby granted, free of charge, to any person obtaining a copy
    of this software and associated documentation files (the "Software"), to deal
    in the Software without restriction, including without limitation the rights
    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
    copies of the Software, and to permit persons to whom the Software is
    furnished to do so, subject to the following conditions:

    The above copyright notice and this permission notice shall be included in all
    copies or substantial portions of the Software.

    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
    SOFTWARE.
    ```
    - ^ For 
      > LICENSE 
      >
      > OWNERSHIP
      >
      > PATENTABILITY
      >
      > ASSOCIATION ('the UNITED STATES OF AMERICA')
    - By 
      > Jeffrey Thomas Bodin
      > 
      > JeffreyBodin
      > 
      > **insert any recognized alias here**

-----

#12 
#Is 

- Dependabot's Commit

```md
    Bumps [node-fetch](https://github.com/node-fetch/node-fetch) from 2.2.0 to 2.6.7.
    - [Release notes](https://github.com/node-fetch/node-fetch/releases)
    - [Changelog](https://github.com/node-fetch/node-fetch/blob/main/docs/CHANGELOG.md)
    - [Commits](https://github.com/node-fetch/node-fetch/compare/v2.2.0...v2.6.7)
    
    ---
    updated-dependencies:
    - dependency-name: node-fetch
      dependency-type: indirect
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>
```

-----

```

2022-01-28_0325 signed-off-by: JeffreyBodin <jeffreybodin713@gmail.com>